### PR TITLE
mayday:  adding general OS commands

### DIFF
--- a/cmd/mayday.go
+++ b/cmd/mayday.go
@@ -30,11 +30,45 @@ var (
 			Link: "meminfo",
 		},
 		{
+			Path: "/etc/os-release",
+			Link: "os-release",
+		},
+		{
 			Path: "/proc/mounts",
 			Link: "mounts",
 		},
 	}
 	commands = []mayday.Command{
+		{
+			Args: []string{"hostname"},
+			Link: "hostname",
+		},
+		{
+			Args: []string{"date"},
+			Link: "date",
+		},
+		{
+			Args: []string{"systemd-cgls"},
+		},
+		{
+			Args: []string{"systemd-cgtop", "-n1"},
+		},
+		{
+			Args: []string{"ps", "fauxwww"},
+			Link: "ps",
+		},
+		{
+			Args: []string{"lsmod"},
+			Link: "lsmod",
+		},
+		{
+			Args: []string{"lspci"},
+			Link: "lspci",
+		},
+		{
+			Args: []string{"lsof", "-b", "-M", "-n", "-l"},
+			Link: "lsof",
+		},
 		{
 			Args: []string{"blkid"},
 		},


### PR DESCRIPTION
capturing the following content to get a better idea about the
overall health of the system, processes running, and hardware:
- /etc/os-release
- hostname
- date
- systemd-cgls
- systemd-cgtop
- ps fauxwww
- lsmod
- lspci
- lsof -b -M -n -l
