### PR TITLE
add rkt parsing and tarables

### DIFF
--- a/mayday/rkt/app.go
+++ b/mayday/rkt/app.go
@@ -1,0 +1,55 @@
+package rkt
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"time"
+)
+
+type AppTarable struct {
+	pod_uuid string
+	apps     []App
+	link     string        // currently never set to anything
+	content  *bytes.Buffer // the contents of the log, populated by Run()
+}
+
+func NewAppTarable(pod Pod) *AppTarable {
+	af := AppTarable{pod_uuid: pod.Uuid, apps: pod.Apps}
+	var buffer bytes.Buffer
+
+	buffer.WriteString("APP\tIMAGE NAME\tIMAGE ID\n")
+	for _, a := range af.apps {
+		buffer.WriteString(a.Name)
+		buffer.WriteString("\t")
+		buffer.WriteString(a.ImageName)
+		buffer.WriteString("\t")
+		buffer.WriteString(a.ImageId)
+		buffer.WriteString("\n")
+	}
+
+	af.content = &buffer
+	return &af
+}
+
+func (a *AppTarable) Header() *tar.Header {
+	var header tar.Header
+	header.Name = "/containers/" + a.pod_uuid + "/apps"
+	header.Mode = 0666
+	header.Size = int64(a.content.Len())
+	header.ModTime = time.Now()
+
+	return &header
+}
+
+func (a *AppTarable) Content() io.Reader {
+	return a.content
+}
+
+func (a *AppTarable) Name() string {
+	return a.pod_uuid
+}
+
+func (a *AppTarable) Link() string {
+	return a.link
+}

--- a/mayday/rkt/app_test.go
+++ b/mayday/rkt/app_test.go
@@ -1,0 +1,54 @@
+package rkt
+
+import (
+	"bytes"
+	"github.com/coreos/mayday/mayday"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAppTarable(t *testing.T) {
+	assert.Implements(t, (*mayday.Tarable)(nil), new(AppTarable))
+
+	var pod Pod
+	var app1 App
+	var app2 App
+
+	app1.Name = "app1"
+	app1.ImageName = "image1"
+	app1.ImageId = "111"
+
+	app2.Name = "app2"
+	app2.ImageName = "image2"
+	app2.ImageId = "222"
+
+	pod.Uuid = "abc123"
+	pod.Apps = []App{app1, app2}
+
+	af := NewAppTarable(pod)
+
+	content := new(bytes.Buffer)
+	content.ReadFrom(af.Content())
+
+	res := "APP\tIMAGE NAME\tIMAGE ID\n" +
+		"app1\timage1\t111\n" +
+		"app2\timage2\t222\n"
+
+	assert.Equal(t, content.String(), res)
+}
+
+func TestAppHeader(t *testing.T) {
+
+	pod := Pod{
+		Uuid: "abc123",
+		Apps: []App{{Name: "app1", ImageName: "image1", ImageId: "111"}},
+	}
+
+	af := NewAppTarable(pod)
+
+	assert.Equal(t, af.Name(), "abc123")
+
+	hdr := af.Header()
+	assert.Equal(t, hdr.Name, "/containers/abc123/apps")
+	assert.Equal(t, hdr.Size, int64(af.content.Len()))
+}

--- a/mayday/rkt/cmd.go
+++ b/mayday/rkt/cmd.go
@@ -1,0 +1,60 @@
+package rkt
+
+import (
+	"strings"
+)
+
+// TODO make this less horrible looking, and less fragile, if possible
+func ProcessRktOutput(output string) []Pod {
+	var pods []Pod
+	var currpod Pod
+
+	lines := strings.Split(output, "\n")
+
+	for i, l := range lines {
+		if i == 0 {
+			continue
+		}
+		if l == "" {
+			break
+		}
+		cols := strings.Split(l, "\t")
+		if cols[0] != "" {
+			// new pod!
+			// if previous pod exists, save it to pods
+			if currpod.initialized {
+				pods = append(pods, currpod)
+			}
+
+			currpod = Pod{
+				initialized: true,
+				Uuid:        cols[0],
+				State:       cols[len(cols)-4],
+				Created:     cols[len(cols)-3],
+				Started:     cols[len(cols)-2],
+				Network:     cols[len(cols)-1]}
+			currpod.Apps = []App{{
+				Name:      cols[1],
+				ImageName: cols[2],
+				ImageId:   cols[len(cols)-5]}}
+		} else {
+			var newApp App
+			for j, c := range cols {
+				if c != "" {
+					newApp = App{
+						Name:      cols[j],
+						ImageName: cols[j+1],
+						ImageId:   cols[j+2],
+					}
+					break
+				}
+			}
+			currpod.Apps = append(currpod.Apps, newApp)
+		}
+	}
+	// save current pod, if it's been initialized
+	if currpod.initialized {
+		pods = append(pods, currpod)
+	}
+	return pods
+}

--- a/mayday/rkt/cmd_test.go
+++ b/mayday/rkt/cmd_test.go
@@ -1,0 +1,46 @@
+package rkt
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const (
+	multi_app_output = `UUID					APP	IMAGE NAME					IMAGE ID		STATE	CREATED					STARTED					NETWORKS
+3edcaaea-acb4-497f-85fa-55014a780568	etcd	coreos.com/etcd:v2.3.7				sha512-7d28419b27d5	running	2016-07-12 13:59:10.606 -0700 PDT	2016-07-12 13:59:10.757 -0700 PDT	default:ip4=172.16.28.2
+					nginx	registry-1.docker.io/library/nginx:latest	sha512-a119eb68f973
+f62c02b1-a514-4f92-b965-610eea629a60	etcd	coreos.com/etcd:v2.3.7				sha512-7d28419b27d5	exited	2016-07-12 13:10:39.777 -0700 PDT	2016-07-12 13:10:39.871 -0700 PDT	default:ip4=172.16.28.5
+`
+
+	empty = `UUID					APP	IMAGE NAME					IMAGE ID		STATE	CREATED					STARTED					NETWORKS
+`
+)
+
+func TestProcessMultiAppRkt(t *testing.T) {
+	pods := ProcessRktOutput(multi_app_output)
+
+	assert.Equal(t, len(pods), 2)
+
+	assert.Equal(t, pods[0].Uuid, "3edcaaea-acb4-497f-85fa-55014a780568")
+	assert.Equal(t, pods[0].State, "running")
+	assert.Equal(t, pods[0].Network, "default:ip4=172.16.28.2")
+	assert.Equal(t, len(pods[0].Apps), 2)
+
+	assert.Equal(t, pods[0].Apps[0].Name, "etcd")
+	assert.Equal(t, pods[0].Apps[0].ImageName, "coreos.com/etcd:v2.3.7")
+	assert.Equal(t, pods[0].Apps[0].ImageId, "sha512-7d28419b27d5")
+
+	assert.Equal(t, pods[0].Apps[1].Name, "nginx")
+	assert.Equal(t, pods[0].Apps[1].ImageName, "registry-1.docker.io/library/nginx:latest")
+	assert.Equal(t, pods[0].Apps[1].ImageId, "sha512-a119eb68f973")
+
+	assert.Equal(t, pods[1].Uuid, "f62c02b1-a514-4f92-b965-610eea629a60")
+	assert.Equal(t, pods[1].State, "exited")
+	assert.Equal(t, pods[1].Network, "default:ip4=172.16.28.5")
+	assert.Equal(t, len(pods[1].Apps), 1)
+}
+
+func TestProcessEmptyRkt(t *testing.T) {
+	pods := ProcessRktOutput(empty)
+	assert.Equal(t, len(pods), 0)
+}

--- a/mayday/rkt/pod.go
+++ b/mayday/rkt/pod.go
@@ -1,0 +1,80 @@
+package rkt
+
+import (
+	"archive/tar"
+	"bytes"
+	"github.com/coreos/mayday/mayday"
+	"io"
+	"time"
+)
+
+type App struct {
+	Name      string
+	ImageName string
+	ImageId   string
+}
+
+// the struct holding all the data about a single pod
+type Pod struct {
+	initialized bool
+	Uuid        string
+	Apps        []App
+	State       string
+	Created     string // these could be dates, but would just mean processing overhead
+	Started     string
+	Network     string
+}
+
+type PodTarable struct {
+	pod_uuid string
+	link     string        // currently never set to anything
+	content  *bytes.Buffer // the contents of the log, populated by Run()
+}
+
+func (p *Pod) GetTarables() []mayday.Tarable {
+	var tarables []mayday.Tarable
+	tarables = append(tarables, NewPodTarable(*p))
+	tarables = append(tarables, NewAppTarable(*p))
+	// tarables = append(tarables, NewLogTarable(&p))
+	return tarables
+}
+
+func NewPodTarable(pod Pod) *PodTarable {
+	pf := PodTarable{pod_uuid: pod.Uuid}
+	var buffer bytes.Buffer
+
+	buffer.WriteString("STATE\tCREATED\tSTARTED\tNETWORKS\n")
+	buffer.WriteString(pod.State)
+	buffer.WriteString("\t")
+	buffer.WriteString(pod.Created)
+	buffer.WriteString("\t")
+	buffer.WriteString(pod.Started)
+	buffer.WriteString("\t")
+	buffer.WriteString(pod.Network)
+	buffer.WriteString("\n")
+
+	pf.content = &buffer
+	return &pf
+}
+
+func (p *PodTarable) Header() *tar.Header {
+	var header tar.Header
+	header.Name = "/containers/" + p.pod_uuid + "/pod"
+	header.Mode = 0666
+	header.Size = int64(p.content.Len())
+	header.ModTime = time.Now()
+
+	return &header
+}
+
+func (p *PodTarable) Content() io.Reader {
+	return p.content
+}
+
+func (p *PodTarable) Name() string {
+	return p.pod_uuid
+}
+
+func (p *PodTarable) Link() string {
+	return p.link
+}

--- a/mayday/rkt/pod_test.go
+++ b/mayday/rkt/pod_test.go
@@ -1,0 +1,49 @@
+package rkt
+
+import (
+	"bytes"
+	"github.com/coreos/mayday/mayday"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPodTarable(t *testing.T) {
+	assert.Implements(t, (*mayday.Tarable)(nil), new(AppTarable))
+
+	pod := Pod{
+		Uuid:    "abc123",
+		State:   "running",
+		Created: "2016-07-12 13:59:10.606 -0700 PDT",
+		Started: "2016-07-12 13:59:10.757 -0700 PDT",
+		Network: "default:ip4=172.16.28.2",
+	}
+
+	pf := NewPodTarable(pod)
+
+	content := new(bytes.Buffer)
+	content.ReadFrom(pf.Content())
+
+	res := "STATE\tCREATED\tSTARTED\tNETWORKS\n" +
+		"running\t" + pod.Created + "\t" + pod.Started + "\t" + pod.Network + "\n"
+
+	assert.Equal(t, content.String(), res)
+}
+
+func TestPodHeader(t *testing.T) {
+
+	pod := Pod{
+		Uuid:    "abc123",
+		State:   "running",
+		Created: "2016-07-12 13:59:10.606 -0700 PDT",
+		Started: "2016-07-12 13:59:10.757 -0700 PDT",
+		Network: "default:ip4=172.16.28.2",
+	}
+
+	pf := NewPodTarable(pod)
+
+	assert.Equal(t, pf.Name(), "abc123")
+
+	hdr := pf.Header()
+	assert.Equal(t, hdr.Name, "/containers/abc123/pod")
+	assert.Equal(t, hdr.Size, int64(pf.content.Len()))
+}

--- a/test
+++ b/test
@@ -17,8 +17,10 @@ if [[ $* == *--coverprofile* ]]; then
 	# generate html cover document
 	mkdir -p tmp/
 	go test github.com/coreos/mayday/mayday -coverprofile tmp/mayday.out
+	go test github.com/coreos/mayday/mayday/rkt -coverprofile tmp/rkt.out
 	go test github.com/coreos/mayday -coverprofile tmp/main.out
 	go tool cover -html=tmp/mayday.out -o tmp/mayday.html
+	go tool cover -html=tmp/rkt.out -o tmp/rkt.html
 	go tool cover -html=tmp/main.out -o tmp/main.html
 else
 	# just report percentage


### PR DESCRIPTION
This is by no means done yet.

This adds the `github.com/coreos/mayday/mayday/rkt` package that is to be used as such:

```
pods = rkt.GetPods() // returns a list of Pods
for _, p := range pods {
    tbs := p.GetTarables() // returns a []Tarable
    for _, t = range tbs {
        tarables = append(tarables, t)
    }
}
```

`GetTarables()` returns three `Tarable`s:
 - `PodTarable` containing the file `/containers/{uuid}/pod`
 - `AppTarable` containing the file `/containers/{uuid}/apps`
 - `LogTarable` containing the file `/containers/{uuid}/{uuid}.log`

So far, if you manually initialize a `Pod` object with `App` objects (or use `ProcessRktOutput(str)` to parse them into existence), you can call `GetTarables()` to get the Pod and App tarables.

I'm not very happy with this api, but it's at the same time the best I can think of.

Thoughts?