### PR TITLE
add docker logging

### DIFF
--- a/mayday.go
+++ b/mayday.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/coreos/mayday/mayday"
+	"github.com/coreos/mayday/mayday/docker"
 	"github.com/coreos/mayday/mayday/rkt"
 
 	"github.com/spf13/pflag"
@@ -84,9 +85,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	pods, logs, err := rkt.GetPods()
+	pods, rktLogs, err := rkt.GetPods()
 	if err != nil {
 		log.Println("Could not connect to rkt. Verify mayday has permissions to launch the rkt client.")
+		log.Printf("Connection error: %s", err)
+	}
+
+	containers, dockerLogs, err := docker.GetContainers()
+	if err != nil {
+		log.Println("Could not connect to docker. Verify mayday has permissions to read /var/lib/docker.")
 		log.Printf("Connection error: %s", err)
 	}
 
@@ -111,7 +118,15 @@ func main() {
 		tarables = append(tarables, p)
 	}
 
-	for _, l := range logs {
+	for _, l := range rktLogs {
+		tarables = append(tarables, l)
+	}
+
+	for _, c := range containers {
+		tarables = append(tarables, c)
+	}
+
+	for _, l := range dockerLogs {
 		tarables = append(tarables, l)
 	}
 

--- a/mayday/command.go
+++ b/mayday/command.go
@@ -36,6 +36,10 @@ func (c *Command) Name() string {
 	return c.Output
 }
 
+func (c *Command) Args() []string {
+	return c.args
+}
+
 func (c *Command) Header() *tar.Header {
 	// content needs to be populated before the header can be generated
 	if c.content == nil {

--- a/mayday/docker/docker.go
+++ b/mayday/docker/docker.go
@@ -1,0 +1,132 @@
+package docker
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"github.com/coreos/mayday/mayday"
+	"github.com/spf13/viper"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+)
+
+const (
+	dockerDir = "/var/lib/docker/containers"
+)
+
+type DockerContainer struct {
+	containerId string        // container id
+	file        io.Reader     // config file -- /var/lib/docker/containers/{uuid}/config.v2.json
+	content     *bytes.Buffer // a Buffer containing the contents of the file
+	link        string        // a link to make in the root of the tarball
+}
+
+func New(f io.Reader, uuid string) DockerContainer {
+	dc := DockerContainer{containerId: uuid, file: f}
+	return dc
+}
+
+func (d *DockerContainer) Content() io.Reader {
+	if d.content != nil {
+		return d.content
+	}
+
+	if viper.GetBool("danger") {
+		var b bytes.Buffer
+		writer := bufio.NewWriter(&b)
+		io.Copy(writer, d.file)
+
+		d.content = &b
+		return d.content
+	}
+
+	// unmarshal docker config into interface
+	var config interface{}
+
+	fileContent, err := ioutil.ReadAll(d.file)
+	if err != nil {
+		log.Printf("error reading docker container configuration: %s", err)
+	}
+
+	err = json.Unmarshal(fileContent, &config)
+	if err != nil {
+		log.Printf("error reading docker container configuration: %s", err)
+	}
+	configInterface := config.(map[string]interface{})
+	configConfig := configInterface["Config"].(map[string]interface{})
+	delete(configConfig, "Env")
+
+	byteContent, err := json.MarshalIndent(configInterface, "", "  ")
+	if err != nil {
+		log.Print("error saving docker container configuration!")
+	}
+
+	d.content = bytes.NewBuffer(byteContent)
+	return d.content
+}
+
+func (d *DockerContainer) Header() *tar.Header {
+	if d.content == nil {
+		d.Content()
+	}
+
+	var header tar.Header
+	header.Name = "/docker/" + d.containerId
+	header.Size = int64(d.content.Len())
+	header.Mode = 0666
+	header.ModTime = time.Now()
+
+	return &header
+}
+
+func (d *DockerContainer) Name() string {
+	return d.containerId
+}
+
+func (d *DockerContainer) Link() string {
+	return d.link
+}
+
+func getLogs(containers []*DockerContainer) []*mayday.Command {
+	var logs []*mayday.Command
+	if viper.GetBool("danger") {
+		log.Println("Danger mode activated. Dump will include docker container logs and environment variables, which may contain sensitive information.")
+		if len(containers) != 0 {
+			for _, c := range containers {
+				logcmd := []string{"docker", "logs", c.Name()}
+				cmd := mayday.NewCommand(logcmd, "")
+				cmd.Output = "/docker/" + c.Name() + ".log"
+				logs = append(logs, cmd)
+			}
+		}
+	}
+	return logs
+}
+
+func GetContainers() ([]*DockerContainer, []*mayday.Command, error) {
+	var containers []*DockerContainer
+	var logs []*mayday.Command
+
+	files, err := ioutil.ReadDir(dockerDir)
+	if err != nil {
+		return containers, logs, err
+	}
+
+	for _, file := range files {
+		f, err := os.Open(dockerDir + "/" + file.Name() + "/config.v2.json")
+		if err != nil {
+			log.Printf("unable to read config for container %s: %s", file.Name(), err)
+			continue
+		}
+		dc := New(f, file.Name())
+		containers = append(containers, &dc)
+	}
+
+	logs = getLogs(containers)
+
+	return containers, logs, nil
+}

--- a/mayday/docker/docker.go
+++ b/mayday/docker/docker.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -49,8 +50,14 @@ func (d *DockerContainer) Content() io.Reader {
 	configInterface := config.(map[string]interface{})
 
 	if !viper.GetBool("danger") {
-		configConfig := configInterface["Config"].(map[string]interface{})
-		delete(configConfig, "Env")
+		configMap := configInterface["Config"].(map[string]interface{})
+		env := configMap["Env"].([]interface{})
+		var newEnv []string
+		for _, e := range env {
+			varSplit := strings.SplitAfterN(e.(string), "=", 2)
+			newEnv = append(newEnv, varSplit[0]+"scrubbed by mayday")
+		}
+		configMap["Env"] = newEnv
 	}
 
 	byteContent, err := json.MarshalIndent(configInterface, "", "  ")

--- a/mayday/docker/docker_test.go
+++ b/mayday/docker/docker_test.go
@@ -1,0 +1,114 @@
+package docker
+
+import (
+	"encoding/json"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+const (
+	dcString      = `{"Config": {"Safe": "abc", "Env": [1, 2, 3]}}`
+	dcStringNoEnv = `{"Config": {"Safe": "abc"}}` // same as dcString but with env vars deleted
+	dcUuid        = "do-re-mi-abc-123"
+)
+
+func TestStruct(t *testing.T) {
+	dc := New(strings.NewReader(dcString), dcUuid)
+
+	assert.Equal(t, dc.Name(), dcUuid)
+	assert.Equal(t, dc.Link(), "") // docker containers don't have links
+
+	assert.EqualValues(t, dc.file, strings.NewReader(dcString))
+}
+
+func TestHeader(t *testing.T) {
+	dc := New(strings.NewReader(dcString), dcUuid)
+	h := dc.Header()
+
+	// the resultant string might have different whitespace and thus be larger,
+	// but it won't be larger than the string containing the env information.
+	assert.True(t, int(h.Size) > len(dcStringNoEnv))
+	assert.True(t, int(h.Size) < len(dcString))
+	assert.Equal(t, h.Name, "/docker/"+dcUuid)
+}
+
+func TestRepeatedContentCalling(t *testing.T) {
+	// Content() should return the same pointer on multiple calls -- there's
+	// no need to reparse json, re-read files, etc.
+	dc := New(strings.NewReader(dcString), dcUuid)
+	call1 := dc.Content()
+	call2 := dc.Content()
+	assert.Equal(t, &call1, &call2)
+}
+
+func TestGetLogsDanger(t *testing.T) {
+	viper.Set("danger", true)
+	defer viper.Set("danger", false)
+	var containers []*DockerContainer
+	c1 := New(strings.NewReader(dcString), dcUuid)
+	c2 := New(strings.NewReader("content2"), "xyz")
+	containers = append(containers, &c1)
+	containers = append(containers, &c2)
+
+	logs := getLogs(containers)
+	assert.Equal(t, len(logs), 2)
+
+	assert.Equal(t, logs[0].Output, "/docker/do-re-mi-abc-123.log")
+	assert.Equal(t, logs[1].Output, "/docker/xyz.log")
+
+	assert.Equal(t, logs[0].Args(), []string{"docker", "logs", "do-re-mi-abc-123"})
+	assert.Equal(t, logs[1].Args(), []string{"docker", "logs", "xyz"})
+}
+
+func TestGetLogsSafe(t *testing.T) {
+	viper.Set("danger", false)
+	var containers []*DockerContainer
+	c1 := New(strings.NewReader(dcString), dcUuid)
+	c2 := New(strings.NewReader("content2"), "xyz")
+	containers = append(containers, &c1)
+	containers = append(containers, &c2)
+
+	logs := getLogs(containers)
+	assert.Equal(t, len(logs), 0)
+
+}
+
+func TestContentSafeMode(t *testing.T) {
+	dc := New(strings.NewReader(dcString), dcUuid)
+	c := dc.Content()
+
+	var cParsed interface{}
+	var dcParsed map[string]interface{}
+
+	cbytes, _ := ioutil.ReadAll(c)
+
+	json.Unmarshal(cbytes, &cParsed)
+	// after passing through dc.Content(), the env variables should be deleted
+	// (as the --danger flag has not been set)
+	json.Unmarshal([]byte(dcStringNoEnv), &dcParsed)
+
+	assert.Equal(t, cParsed, dcParsed)
+	config := cParsed.(map[string]interface{})["Config"]
+	_, keyInMap := config.(map[string]interface{})["Env"]
+	assert.False(t, keyInMap)
+}
+
+func TestContentDangerMode(t *testing.T) {
+	viper.Set("danger", true)
+	defer viper.Set("danger", false)
+	dc := New(strings.NewReader(dcString), dcUuid)
+	c := dc.Content()
+
+	var cParsed map[string]interface{}
+	var dcParsed map[string]interface{}
+
+	json.NewDecoder(c).Decode(cParsed)
+	// after passing through dc.Content(), the env variables should NOT be deleted
+	// (as the --danger flag has been set)
+	json.Unmarshal([]byte(dcString), dcParsed)
+
+	assert.EqualValues(t, cParsed, dcParsed)
+}

--- a/test
+++ b/test
@@ -18,10 +18,12 @@ if [[ $* == *--coverprofile* ]]; then
 	mkdir -p tmp/
 	go test github.com/coreos/mayday/mayday -coverprofile tmp/mayday.out
 	go test github.com/coreos/mayday/mayday/rkt -coverprofile tmp/rkt.out
+	go test github.com/coreos/mayday/mayday/docker -coverprofile tmp/docker.out
 	go test github.com/coreos/mayday -coverprofile tmp/main.out
 	go tool cover -html=tmp/mayday.out -o tmp/mayday.html
 	go tool cover -html=tmp/main.out -o tmp/main.html
 	go tool cover -html=tmp/rkt.out -o tmp/rkt.html
+	go tool cover -html=tmp/docker.out -o tmp/docker.html
 else
 	# just report percentage
 	go test github.com/coreos/mayday github.com/coreos/mayday/mayday/... -cover


### PR DESCRIPTION
This reads and copies `/var/lib/docker/containers/{uuid}/config.v2.json`.

If mayday isn't in danger mode, the Config->Env portion is deleted.
If mayday *is* in danger mode, logs are collected using `docker logs`.