### PR TITLE
bug: ORG_PATH and REPO_PATH could not be set

### DIFF
--- a/build
+++ b/build
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-ORG_PATH="github.com/coreos"
-REPO_PATH="${ORG_PATH}/mayday"
+ORG_PATH="${ORG_PATH:-github.com/coreos}"
+REPO_PATH="${REPO_PATH:-${ORG_PATH}/mayday}"
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then
 	mkdir -p gopath/src/${ORG_PATH}


### PR DESCRIPTION
The previous configuration of ORG_PATH and REPO_PATH did not allow them
to be set in the environment.  This had the limitation of not allowing
for runtime collaboration of builds and tests.

Previous behavior:

```
[bharrington@leviathan mayday]$ ORG_PATH="github.com/brianredbeard" bash
-x ./build
+ ORG_PATH=github.com/coreos
+ REPO_PATH=github.com/coreos/mayday
+ '[' '!' -h gopath/src/github.com/coreos/mayday ']'
+ export
GOBIN=/home/bharrington/Projects/golang/src/github.com/brianredbeard/mayday/bin
+
GOBIN=/home/bharrington/Projects/golang/src/github.com/brianredbeard/mayday/bin
++ go env
+ eval 'GOARCH="amd64"'
'GOBIN="/home/bharrington/Projects/golang/src/github.com/brianredbeard/mayday/bin"'
'GOEXE=""' 'GOHOSTARCH="amd64"' 'GOHOSTOS="linux"' 'GOOS="linux"'
'GOPATH="/home/bharrington/Projects/golang"' 'GORACE=""'
'GOROOT="/usr/local/golang/latest/go"'
'GOTOOLDIR="/usr/local/golang/latest/go/pkg/tool/linux_amd64"'
'GO15VENDOREXPERIMENT="1"' 'CC="gcc"' 'GOGCCFLAGS="-fPIC' -m64 -pthread
'-fmessage-length=0"' 'CXX="g++"' 'CGO_ENABLED="1"'
++ GOARCH=amd64
++
GOBIN=/home/bharrington/Projects/golang/src/github.com/brianredbeard/mayday/bin
++ GOEXE=
++ GOHOSTARCH=amd64
++ GOHOSTOS=linux
++ GOOS=linux
++ GOPATH=/home/bharrington/Projects/golang
++ GORACE=
++ GOROOT=/usr/local/golang/latest/go
++ GOTOOLDIR=/usr/local/golang/latest/go/pkg/tool/linux_amd64
++ GO15VENDOREXPERIMENT=1
++ CC=gcc
++ GOGCCFLAGS='-fPIC -m64 -pthread -fmessage-length=0'
++ CXX=g++
++ CGO_ENABLED=1
+ echo 'Building mayday...'
Building mayday...
+ go build -o bin/mayday github.com/coreos/mayday
```

New behavior:

```
[bharrington@leviathan mayday]$ ORG_PATH="github.com/brianredbeard" bash
-x ./build
+ ORG_PATH=github.com/brianredbeard
+ REPO_PATH=github.com/brianredbeard/mayday
+ '[' '!' -h gopath/src/github.com/brianredbeard/mayday ']'
+ export
GOBIN=/home/bharrington/Projects/golang/src/github.com/brianredbeard/mayday/bin
+
GOBIN=/home/bharrington/Projects/golang/src/github.com/brianredbeard/mayday/bin
++ go env
+ eval 'GOARCH="amd64"'
'GOBIN="/home/bharrington/Projects/golang/src/github.com/brianredbeard/mayday/bin"'
'GOEXE=""' 'GOHOSTARCH="amd64"' 'GOHOSTOS="linux"' 'GOOS="linux"'
'GOPATH="/home/bharrington/Projects/golang"' 'GORACE=""'
'GOROOT="/usr/local/golang/latest/go"'
'GOTOOLDIR="/usr/local/golang/latest/go/pkg/tool/linux_amd64"'
'GO15VENDOREXPERIMENT="1"' 'CC="gcc"' 'GOGCCFLAGS="-fPIC' -m64 -pthread
'-fmessage-length=0"' 'CXX="g++"' 'CGO_ENABLED="1"'
++ GOARCH=amd64
++
GOBIN=/home/bharrington/Projects/golang/src/github.com/brianredbeard/mayday/bin
++ GOEXE=
++ GOHOSTARCH=amd64
++ GOHOSTOS=linux
++ GOOS=linux
++ GOPATH=/home/bharrington/Projects/golang
++ GORACE=
++ GOROOT=/usr/local/golang/latest/go
++ GOTOOLDIR=/usr/local/golang/latest/go/pkg/tool/linux_amd64
++ GO15VENDOREXPERIMENT=1
++ CC=gcc
++ GOGCCFLAGS='-fPIC -m64 -pthread -fmessage-length=0'
++ CXX=g++
++ CGO_ENABLED=1
+ echo 'Building mayday...'
Building mayday...
+ go build -o bin/mayday github.com/brianredbeard/mayday
```