### PR TITLE
Fix file handling

### DIFF
--- a/mayday.go
+++ b/mayday.go
@@ -44,7 +44,6 @@ func openFile(f File) (*file.MaydayFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer content.Close()
 
 	fi, err := os.Stat(f.Name)
 	if err != nil {
@@ -107,6 +106,7 @@ func main() {
 		if err != nil {
 			log.Printf("error opening %s: %s\n", f.Name, err)
 		} else {
+			defer mf.Close()
 			tarables = append(tarables, mf)
 		}
 	}

--- a/mayday/plugins/file/file.go
+++ b/mayday/plugins/file/file.go
@@ -4,18 +4,19 @@ import (
 	"archive/tar"
 	"bytes"
 	"io"
+	"io/ioutil"
 	"log"
 )
 
 type MaydayFile struct {
 	name    string        // the name of the file on the filesystem
-	file    io.Reader     // the file handler. Not populated until read
+	file    io.ReadCloser // the file handler. Not populated until read
 	header  *tar.Header   // a Header containing file path, file size, etc
 	content *bytes.Buffer // contents of the file, copied in by .Content()
 	link    string        // a link to make in the root of the tarball
 }
 
-func New(c io.Reader, h *tar.Header, n string, l string) *MaydayFile {
+func New(c io.ReadCloser, h *tar.Header, n string, l string) *MaydayFile {
 	f := new(MaydayFile)
 	f.name = n
 	f.header = h
@@ -25,14 +26,19 @@ func New(c io.Reader, h *tar.Header, n string, l string) *MaydayFile {
 	return f
 }
 
-func (f MaydayFile) Content() *bytes.Buffer {
-	log.Printf("Collecting file: %q\n", f.name)
-	f.content = new(bytes.Buffer)
-	f.content.ReadFrom(f.content)
+func (f *MaydayFile) Content() *bytes.Buffer {
+	if f.content == nil {
+		log.Printf("Collecting file: %q\n", f.name)
+		fbytes, err := ioutil.ReadAll(f.file)
+		if err != nil {
+			log.Printf("error reading file: %s", err)
+		}
+		f.content = bytes.NewBuffer(fbytes)
+	}
 	return f.content
 }
 
-func (f MaydayFile) Header() *tar.Header {
+func (f *MaydayFile) Header() *tar.Header {
 	if f.content == nil {
 		f.Content()
 	}
@@ -40,10 +46,14 @@ func (f MaydayFile) Header() *tar.Header {
 	return f.header
 }
 
-func (f MaydayFile) Name() string {
+func (f *MaydayFile) Name() string {
 	return f.name
 }
 
-func (f MaydayFile) Link() string {
+func (f *MaydayFile) Link() string {
 	return f.link
+}
+
+func (f *MaydayFile) Close() error {
+	return f.file.Close()
 }


### PR DESCRIPTION
Only copy the file content into `f.content` once, and make `File` a Closer so that it can be properly closed at the end of `main()`.