### PR TITLE
add uptime and loadavg files

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,6 +6,12 @@
       "name": "/proc/meminfo",
       "link": "meminfo"
     }, {
+      "name": "/proc/uptime",
+      "link": "uptime"
+    }, {
+      "name": "/proc/loadavg",
+      "link": "loadavg"
+    }, {
       "name": "/proc/mounts",
       "link": "mounts"
     }, {


### PR DESCRIPTION
Closes #60. 

As far as I can tell, we don't currently collect the uptime. It's not a particularly expensive syscall to just grab `/proc/uptime`: https://github.com/torvalds/linux/blob/5924bbecd0267d87c24110cbe2041b5075173a25/fs/proc/uptime.c

```
tschuy@tschuy:(mayday)(uptime) → cat test.c
#include <stdio.h>
#include <stdlib.h>

int main(void)
{
    int i;

    FILE * fp;
    for (i = 0; i < 1000000; i++) {
        fp=fopen("/proc/uptime", "r");
	fclose(fp);
    }
    return 0;
}
tschuy@tschuy:(mayday)(uptime) → time ./getuptime 

real	0m3.516s
user	0m0.257s
sys	0m3.250s
```

3.5 microseconds per read for uptime, and very similar timing for loadavg.