### PR TITLE
add uptime and dmesg

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,6 +19,14 @@
       "link": "hostname"
     },
     {
+      "args": ["uptime"],
+      "link": "uptime"
+    },
+    {
+      "args": ["dmesg"],
+      "link": "dmesg"
+    },
+    {
       "args": ["date"],
       "link": "date"
     },


### PR DESCRIPTION
closes #60.

We don't currently collect load average, uptime, or kernel log info anywhere.