### PR TITLE
Fix nil pointer exception in docker config redaction

### DIFF
--- a/mayday/plugins/journal/journal.go
+++ b/mayday/plugins/journal/journal.go
@@ -89,7 +89,6 @@ func (j *SystemdJournal) Link() string {
 }
 
 func (j *SystemdJournal) Run() error {
-
 	var b bytes.Buffer
 	j.content = &b
 	writer := bufio.NewWriter(j.content)


### PR DESCRIPTION
See https://github.com/coreos/bugs/issues/2077

See also the commit comment.

This code is quite verbose, but that's what proper error handling in go gets you. It might be worth splitting out a few helper functions.