### PR TITLE
Add possibility to include directory trees in config

### DIFF
--- a/mayday_test.go
+++ b/mayday_test.go
@@ -18,6 +18,12 @@ const (
       "link": "meminfo"
     }
   ],
+  "directories": [
+    {
+      "name": "/var/log",
+      "link": "logs"
+    }
+  ],
   "commands": [
     {
       "args": ["hostname"]
@@ -47,4 +53,6 @@ func TestConfigStruct(t *testing.T) {
 
 	assert.EqualValues(t, C.Files[0], File{Name: "/proc/vmstat"})
 	assert.EqualValues(t, C.Files[1], File{Name: "/proc/meminfo", Link: "meminfo"})
+
+	assert.EqualValues(t, C.Directories[0], Directory{Name: "/var/log", Link: "logs"})
 }


### PR DESCRIPTION
This adds another section, 'directories', to the config files, specifying a
directory which to recursively traverse and add all normal files found to
tarables.

The use case for this is when you want to collect several log files, that may
have been rotated, for example.